### PR TITLE
added **kwargs to chat_post_message to allow more parameters

### DIFF
--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -43,9 +43,7 @@ class SlackClient(object):
             'channel': channel,
             'text': text,
         }
-        print "kwargs=", kwargs
         params.update(kwargs)
-        print "params=", params
         if username is not None:
             params['username'] = username
         if parse is not None:


### PR DESCRIPTION
More parameters may include "icon_url", which is what I wanted to use, but there are more such as "unfurl_links" and "icon_emoji". This approach allows the method to seamlessly support more API parameters from Slack without explicitly parameterizing them. In fact it might even be a good idea to just skip username, parse, and link_names, and use the same **kwargs pass through with them.
