### PR TITLE
fixing install issue because of missing requests lib

### DIFF
--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -1,10 +1,5 @@
-
 import logging
-
 import requests
-
-
-__version__ = "0.2.1"
 
 
 class SlackError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
 
 from distutils.core import setup
 
-from pyslack import __version__
-
 
 setup(
     name="pyslack",
-    version=__version__,
+    version="0.2.1",
     description="A Python wrapper for Slack's API",
     author="@LoisaidaSam",
     author_email="sam.sandberg@gmail.com",


### PR DESCRIPTION
quick fix for version issue.

pyslack won't install when you don't have `requests` installed because of _setup.py_ import of the init file. this is not an ideal fix, but gets things happy.
