### PR TITLE
Test Suite and Handling of HTTP 429 Response

### DIFF
--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -1,6 +1,6 @@
+import datetime
 import logging
 import requests
-from datetime import datetime, timedelta
 
 
 class SlackError(Exception):
@@ -22,7 +22,7 @@ class SlackClient(object):
         http://requests.readthedocs.org/en/latest/user/advanced/#ssl-cert-verification
         """
         if self.blocked_until is not None and \
-                datetime.now() < self.blocked_until:
+                datetime.datetime.utcnow() < self.blocked_until:
             raise SlackError("Too many requests - wait until {0}" \
                     .format(self.blocked_until))
 
@@ -33,7 +33,8 @@ class SlackClient(object):
         if response.status_code == 429:
             # Too many requests
             retry_after = int(response.headers.get('retry-after', '1'))
-            self.blocked_until = datetime.now() + timedelta(seconds=retry_after)
+            self.blocked_until = datetime.datetime.utcnow() + \
+                    datetime.timedelta(seconds=retry_after)
             raise SlackError("Too many requests - retry after {0} second(s)" \
                     .format(retry_after))
 

--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import requests
+from datetime import datetime, timedelta
 
 
 class SlackError(Exception):
@@ -12,6 +13,7 @@ class SlackClient(object):
 
     def __init__(self, token):
         self.token = token
+        self.blocked_until = None
 
     def _make_request(self, method, params):
         """Make request to API endpoint
@@ -19,9 +21,23 @@ class SlackClient(object):
         Note: Ignoring SSL cert validation due to intermittent failures
         http://requests.readthedocs.org/en/latest/user/advanced/#ssl-cert-verification
         """
+        if self.blocked_until is not None and \
+                datetime.now() < self.blocked_until:
+            raise SlackError("Too many requests - wait until {0}" \
+                    .format(self.blocked_until))
+
         url = "%s/%s" % (SlackClient.BASE_URL, method)
         params['token'] = self.token
-        result = requests.post(url, data=params, verify=False).json()
+        response = requests.post(url, data=params, verify=False)
+
+        if response.status_code == 429:
+            # Too many requests
+            retry_after = int(response.headers.get('retry-after', '1'))
+            self.blocked_until = datetime.now() + timedelta(seconds=retry_after)
+            raise SlackError("Too many requests - retry after {0} second(s)" \
+                    .format(retry_after))
+
+        result = response.json()
         if not result['ok']:
             raise SlackError(result['error'])
         return result

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from datetime import datetime, timedelta
+import datetime
 import unittest
 
 from mock import Mock, patch
@@ -49,7 +49,7 @@ class ClientTest(unittest.TestCase):
 
         self.assertEqual(r_post.call_count, 1)
         self.assertGreater(client.blocked_until, 
-                datetime.now() + timedelta(seconds=8))
+                datetime.datetime.utcnow() + datetime.timedelta(seconds=8))
 
         # A second send attempt should also throw, but without creating a request
         with self.assertRaises(pyslack.SlackError) as context:
@@ -58,7 +58,8 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(r_post.call_count, 1)
 
         # After the time has expired, it should be business as usual
-        client.blocked_until = datetime.now() - timedelta(seconds=5)
+        client.blocked_until = datetime.datetime.utcnow() - \
+                datetime.timedelta(seconds=5)
 
         r_post.return_value = Mock(status_code=200)
         r_post.return_value.json.return_value = {"ok": True}


### PR DESCRIPTION
Hi there,

I plan to add handling of the ```HTTP 429 Too Many Requests``` error, but felt safer attacking that problem with a test suite in place.

So, here 'tis.

Gavin.