### PR TITLE
Added ability to send 'attachment'

### DIFF
--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -83,6 +83,20 @@ class SlackClient(object):
             'text': text,
         })
         return self._make_request(method, params)
+        
+    def chat_post_attachment(self, channel, text, **params):
+        """chat.postMessage
+
+        This method posts a message to a channel.
+
+        https://api.slack.com/methods/chat.postMessage
+        """
+        method = 'chat.postMessage'
+        params.update({
+            'channel': channel,
+            'attachments': text,
+        })
+        return self._make_request(method, params)
 
     def chat_update_message(self, channel, text, timestamp, **params):
         """chat.update


### PR DESCRIPTION
Allows for sending attachments to a channel following guidlines at https://api.slack.com/docs/attachments.

Interact with it in a similar way to sending a message:

message = '''[
        {
            "fallback": "Required plain-text summary of the attachment.",

            "color": "#36a64f",

            "pretext": "Optional text that appears above the attachment block",

            "author_name": "Bobby Tables",
            "author_link": "http://flickr.com/bobby/",
            "author_icon": "http://flickr.com/icons/bobby.jpg",

            "title": "Slack API Documentation",
            "title_link": "https://api.slack.com/",

            "text": "Optional text that appears within the attachment",

            "fields": [
                {
                    "title": "Priority",
                    "value": "High",
                    "short": false
                }
            ],

            "image_url": "http://my-website.com/path/to/image.jpg"
        }
    ]'''

def post_attachment(recipient, message):
   client = SlackClient('TOKEN')
   client.chat_post_attachment(recipient, message, username='BotName', icon_emoji=":cop:")

post_attachment('#Channel',message)