### PR TITLE
Add files.upload support as file_upload() into pyslack

### DIFF
--- a/pyslack/__init__.py
+++ b/pyslack/__init__.py
@@ -20,7 +20,7 @@ class SlackClient(object):
     def _channel_is_name(self, channel):
         return channel.startswith('#')
 
-    def _make_request(self, method, params):
+    def _make_request(self, method, params, files=None):
         """Make request to API endpoint
 
         Note: Ignoring SSL cert validation due to intermittent failures
@@ -33,7 +33,7 @@ class SlackClient(object):
 
         url = "%s/%s" % (SlackClient.BASE_URL, method)
         params['token'] = self.token
-        response = requests.post(url, data=params, verify=self.verify)
+        response = requests.post(url, data=params, verify=self.verify, files=files)
 
         if response.status_code == 429:
             # Too many requests
@@ -108,6 +108,31 @@ class SlackClient(object):
         })
         return self._make_request(method, params)
 
+    def file_upload(self, channels, file, **params):
+        """files.upload
+        
+        This method uploads a file.
+        
+        Required parameters:
+            `channels`: An array of the channels names to share the file
+            `file`: The file path to upload
+        
+        https://api.slack.com/methods/files.upload   
+        """
+        method = 'files.upload'
+        channel_ids = []
+        for channel in channels:
+            if self._channel_is_name(channel):
+                # If the channel id is not found, will share the file as private by default 
+                channel_ids.append(self.channel_name_to_id(channel))
+        
+        params.update({
+            'channels': ','.join(channel_ids),
+        })
+        
+        files = {'file': open(file, 'rb')}
+        
+        return self._make_request(method, params, files)
 
 class SlackHandler(logging.Handler):
     """A logging handler that posts messages to a Slack channel!


### PR DESCRIPTION
Just added some code to support the files.upload method. Not able to write a successful mock test so I attach some test code and result here:

```python
from pyslack import SlackClient

slack = SlackClient('xxxxxxx')
res = slack.file_upload(['#test-everything'],'event_handler.py', filetype='py')
print res
```

```
{u'ok': True, u'file': {u'filetype': u'python', u'lines_more': 0, u'channels': [u'C077NK40J'], u'display_as_bot': False, u'id': u'F08V40GFR', u'size': 369, u'url_download': u'https://slack-files.com/files-pub/T04D85BG2-F08V40GFR-0ce8bd5b7a/download/event_handler.py', u'title': u'event handler', u'url_private': u'https://files.slack.com/files-pri/T04D85BG2-F08V40GFR/event_handler.py', ...}}
```

![image](https://cloud.githubusercontent.com/assets/3627009/9214705/8e7b60fe-40d3-11e5-81d5-15a0e117c0da.png)
